### PR TITLE
meta-acpi: add LAYERSERIES_COMPAT assignments

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,3 +10,4 @@ BBFILE_PATTERN_acpi = "^${LAYERDIR}/"
 BBFILE_PRIORITY_acpi = "6"
 
 LAYERDEPENDS_acpi = "intel"
+LAYERSERIES_COMPAT_acpi = "rocko sumo"


### PR DESCRIPTION
Yocto sumo now shows a warning when the compat statement is not there.