### PR TITLE
acpi updates for linux 4.18

### DIFF
--- a/recipes-bsp/acpi-tables/samples/edison/arduino.asli
+++ b/recipes-bsp/acpi-tables/samples/edison/arduino.asli
@@ -107,10 +107,10 @@ Scope (\_SB.PCI0.I2C1)
             ToUUID("dbb8e3e6-5886-4ba6-8795-1319f52a966b"),
             Package () {
 #if MUX_I2C
-                Package () {"i2c6-sda-mux", IDMX},
-                Package () {"i2c6-scl-mux", ICMX},
-                Package () {"i2c6-sda-pu", IDPU},
-                Package () {"i2c6-scl-pu", ICPU},
+                Package () {"i2c6-sda-mux",  "\\_SB.PCI0.I2C1.NIO1.IDMX"},
+                Package () {"i2c6-scl-mux",  "\\_SB.PCI0.I2C1.NIO1.ICMX"},
+                Package () {"i2c6-sda-pu",  "\\_SB.PCI0.I2C1.NIO1.IDPU"},
+                Package () {"i2c6-scl-pu",  "\\_SB.PCI0.I2C1.NIO1.ICPU"},
 #endif
             }
 #endif
@@ -190,17 +190,17 @@ Scope (\_SB.PCI0.I2C1)
             ToUUID("dbb8e3e6-5886-4ba6-8795-1319f52a966b"),
             Package () {
 #if MUX_UART
-                Package () {"uart1-rx-pu", URPU},
-                Package () {"uart1-tx-pu", UTPU},
+                Package () {"uart1-rx-pu", "\\_SB.PCI0.I2C1.NIO2.URPU"},
+                Package () {"uart1-tx-pu", "\\_SB.PCI0.I2C1.NIO2.UTPU"},
 #if MUX_UART_4WIRE
-                Package () {"uart1-cts-pu", UCUD},
-                Package () {"uart1-rts-pu", URUD},
+                Package () {"uart1-cts-pu", "\\_SB.PCI0.I2C1.NIO2.UCUD"},
+                Package () {"uart1-rts-pu", "\\_SB.PCI0.I2C1.NIO2.URUD"},
 #endif
 #if MUX_SPI
-                Package () {"ssp5-fs1-pu", SSPU},
-                Package () {"ssp5-txd-pu", STPU},
-                Package () {"ssp5-rxd-pu", SRPU},
-                Package () {"ssp5-clk-pu", SCPU},
+                Package () {"ssp5-fs1-pu", "\\_SB.PCI0.I2C1.NIO2.SSPU"},
+                Package () {"ssp5-txd-pu", "\\_SB.PCI0.I2C1.NIO2.STPU"},
+                Package () {"ssp5-rxd-pu", "\\_SB.PCI0.I2C1.NIO2.SRPU"},
+                Package () {"ssp5-clk-pu", "\\_SB.PCI0.I2C1.NIO2.SCPU"},
 #endif
             }
 #endif
@@ -323,14 +323,14 @@ Scope (\_SB.PCI0.I2C1)
             ToUUID("dbb8e3e6-5886-4ba6-8795-1319f52a966b"),
             Package () {
 #if MUX_I2C
-                Package () {"i2c6-sda-mux", IDMX},
-                Package () {"i2c6-scl-mux", ICMX},
+                Package () {"i2c6-sda-mux", "\\_SB.PCI0.I2C1.NIO3.IDMX"},
+                Package () {"i2c6-scl-mux", "\\_SB.PCI0.I2C1.NIO3.ICMX"},
 #endif
 #if MUX_SPI
-                Package () {"ssp5-fs1-mux", SSMX},
-                Package () {"ssp5-txd-mux", STMX},
-                Package () {"ssp5-rxd-mux", SRMX},
-                Package () {"ssp5-clk-mux", SCMX},
+                Package () {"ssp5-fs1-mux", "\\_SB.PCI0.I2C1.NIO3.SSMX"},
+                Package () {"ssp5-txd-mux", "\\_SB.PCI0.I2C1.NIO3.STMX"},
+                Package () {"ssp5-rxd-mux", "\\_SB.PCI0.I2C1.NIO3.SRMX"},
+                Package () {"ssp5-clk-mux", "\\_SB.PCI0.I2C1.NIO3.SCMX"},
 #endif
             }
 #endif
@@ -431,20 +431,20 @@ Scope (\_SB.PCI0.I2C1)
             ToUUID("dbb8e3e6-5886-4ba6-8795-1319f52a966b"),
             Package () {
 #if MUX_UART
-                Package () {"uart1-rx-oe", UROE},
-                Package () {"uart1-tx-oe", UTOE},
+                Package () {"uart1-rx-oe", "\\_SB.PCI0.I2C1.NIO4.UROE"},
+                Package () {"uart1-tx-oe", "\\_SB.PCI0.I2C1.NIO4.UTOE"},
 #if MUX_UART_4WIRE
-                Package () {"uart1-cts-oe", UCEN},
-                Package () {"uart1-rts-oe", UREN},
+                Package () {"uart1-cts-oe", "\\_SB.PCI0.I2C1.NIO4.UCEN"},
+                Package () {"uart1-rts-oe", "\\_SB.PCI0.I2C1.NIO4.UREN"},
 #endif
 #endif
 #if MUX_SPI
-                Package () {"ssp5-fs1-oe", SSOE},
-                Package () {"ssp5-txd-oe", STOE},
-                Package () {"ssp5-rxd-oe", SROE},
-                Package () {"ssp5-clk-oe", SCOE},
-                Package () {"ssp5-txd-mux", STMX},
-                Package () {"ssp5-fs1-mux", SSMX},
+                Package () {"ssp5-fs1-oe", "\\_SB.PCI0.I2C1.NIO4.SSOE"},
+                Package () {"ssp5-txd-oe", "\\_SB.PCI0.I2C1.NIO4.STOE"},
+                Package () {"ssp5-rxd-oe", "\\_SB.PCI0.I2C1.NIO4.SROE"},
+                Package () {"ssp5-clk-oe", "\\_SB.PCI0.I2C1.NIO4.SCOE"},
+                Package () {"ssp5-txd-mux", "\\_SB.PCI0.I2C1.NIO4.STMX"},
+                Package () {"ssp5-fs1-mux", "\\_SB.PCI0.I2C1.NIO4.SSMX"},
 #endif
             }
 #endif

--- a/recipes-bsp/acpi-tables/samples/edison/arduino.asli
+++ b/recipes-bsp/acpi-tables/samples/edison/arduino.asli
@@ -341,7 +341,7 @@ Scope (\_SB.PCI0.I2C1)
             Package () {
                 Package () {"gpio-hog", 1},
                 Package () {"gpios", Package () {4, 0}},
-                Package () {"output-high", 1},
+                Package () {"output-low", 1},
                 Package () {"line-name", "i2c6-sda-mux"},
             }
         })
@@ -351,7 +351,7 @@ Scope (\_SB.PCI0.I2C1)
             Package () {
                 Package () {"gpio-hog", 1},
                 Package () {"gpios", Package () {5, 0}},
-                Package () {"output-high", 1},
+                Package () {"output-low", 1},
                 Package () {"line-name", "i2c6-scl-mux"},
             }
         })

--- a/recipes-bsp/acpica/acpica_20180810.bb
+++ b/recipes-bsp/acpica/acpica_20180810.bb
@@ -17,9 +17,11 @@ COMPATIBLE_HOST = "(i.86|x86_64|arm|aarch64).*-linux"
 DEPENDS = "bison flex"
 
 SRC_URI = "https://acpica.org/sites/acpica/files/acpica-unix2-${PV}.tar.gz \
-    "
-SRC_URI[md5sum] = "5aa086f71f4b5273c0932a1e04419a37"
-SRC_URI[sha256sum] = "d1e26cdde58938653a277a5ca59ce1df045508d345fee13fed2eaacc6ef51851"
+           file://rename-yy_scan_string-manually.patch \
+           file://manipulate-fds-instead-of-FILE.patch \
+           "
+SRC_URI[md5sum] = "d0c9de5a55d6e8c4765aa9a3c0375652"
+SRC_URI[sha256sum] = "679bac35a761ead4bafbcb5e9e9df3a2acad56622f93409a473a6c00c570b905"
 UPSTREAM_CHECK_URI = "https://acpica.org/downloads"
 
 S = "${WORKDIR}/acpica-unix2-${PV}"

--- a/recipes-bsp/acpica/files/manipulate-fds-instead-of-FILE.patch
+++ b/recipes-bsp/acpica/files/manipulate-fds-instead-of-FILE.patch
@@ -1,0 +1,71 @@
+From 540d80469e6a7dce6baf7214df90e86daffc5175 Mon Sep 17 00:00:00 2001
+From: Fan Xin <fan.xin@jp.fujitsu.com>
+Date: Mon, 5 Jun 2017 13:26:38 +0900
+Subject: [PATCH] aslfiles.c: manipulate fds instead of FILE
+
+Copying what stdout/stderr point to is not portable and fails with
+musl because FILE is an undefined struct.
+
+Instead, use lower-level Unix functions to modify the file that stderr
+writes into. This works on the platforms that Yocto targets.
+
+Upstream-Status: Inappropriate [embedded specific]
+
+Signed-off-by: Patrick Ohly <patrick.ohly@intel.com>
+
+Rebase on acpica 20170303
+
+Signed-off-by: Fan Xin <fan.xin@jp.fujitsu.com>
+
+---
+ source/compiler/aslfiles.c | 15 ++++++++++++---
+ 1 file changed, 12 insertions(+), 3 deletions(-)
+
+diff --git a/source/compiler/aslfiles.c b/source/compiler/aslfiles.c
+index 82865db..cc072dc 100644
+--- a/source/compiler/aslfiles.c
++++ b/source/compiler/aslfiles.c
+@@ -43,6 +43,11 @@
+ 
+ #include "aslcompiler.h"
+ #include "acapps.h"
++#include "dtcompiler.h"
++#include <sys/types.h>
++#include <sys/stat.h>
++#include <fcntl.h>
++#include <unistd.h>
+ 
+ #define _COMPONENT          ACPI_COMPILER
+         ACPI_MODULE_NAME    ("aslfiles")
+@@ -606,6 +611,8 @@ FlOpenMiscOutputFiles (
+ 
+     if (Gbl_DebugFlag)
+     {
++	int fd;
++
+         Filename = FlGenerateFilename (FilenamePrefix, FILE_SUFFIX_DEBUG);
+         if (!Filename)
+         {
+@@ -617,10 +624,10 @@ FlOpenMiscOutputFiles (
+         /* Open the debug file as STDERR, text mode */
+ 
+         Gbl_Files[ASL_FILE_DEBUG_OUTPUT].Filename = Filename;
+-        Gbl_Files[ASL_FILE_DEBUG_OUTPUT].Handle =
+-            freopen (Filename, "w+t", stderr);
+ 
+-        if (!Gbl_Files[ASL_FILE_DEBUG_OUTPUT].Handle)
++        fd = open(Filename, O_CREAT|O_TRUNC, S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP|S_IROTH|S_IWOTH);
++        if (fd < 0 ||
++            dup2(fd, fileno(stderr)))
+         {
+             /*
+              * A problem with freopen is that on error, we no longer
+@@ -634,6 +641,8 @@ FlOpenMiscOutputFiles (
+             exit (1);
+         }
+ 
++        Gbl_Files[ASL_FILE_DEBUG_OUTPUT].Handle = stderr;
++
+         AslCompilerSignon (ASL_FILE_DEBUG_OUTPUT);
+         AslCompilerFileHeader (ASL_FILE_DEBUG_OUTPUT);
+     }

--- a/recipes-bsp/acpica/files/rename-yy_scan_string-manually.patch
+++ b/recipes-bsp/acpica/files/rename-yy_scan_string-manually.patch
@@ -1,0 +1,64 @@
+From 2ab61e6ad5a9cfcde838379bc36babfaaa61afb8 Mon Sep 17 00:00:00 2001
+From: Patrick Ohly <patrick.ohly@intel.com>
+Date: Fri, 20 Jan 2017 13:50:17 +0100
+Subject: [PATCH] rename yy_scan_string manually
+
+flex 2.6.0 used to generate code where yy_scan_string was mapped
+to <custom prefix>_scan_string directly in the generated .c code.
+
+For example, generate/unix/iasl/obj/prparserlex.c:
+
+int
+PrInitLexer (
+    char                    *String)
+{
+
+    LexBuffer = PrParser_scan_string (String);
+    return (LexBuffer == NULL);
+}
+
+flex 2.6.3 no longer does that, leading to a compiler warning
+and link error about yy_scan_string().
+
+Both versions generate a preamble in the beginning of prparserlex.c
+that maps several yy_* names, but yy_scan_string is not among those:
+
+...
+...
+
+Upstream-Status: Inappropriate [workaround for https://github.com/westes/flex/issues/164]
+Signed-off-by: Patrick Ohly <patrick.ohly@intel.com>
+---
+ source/compiler/dtparser.l | 2 +-
+ source/compiler/prparser.l | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/source/compiler/dtparser.l b/source/compiler/dtparser.l
+index 3f4c2f3..eaa43ff 100644
+--- a/source/compiler/dtparser.l
++++ b/source/compiler/dtparser.l
+@@ -120,7 +120,7 @@ DtInitLexer (
+     char                    *String)
+ {
+ 
+-    LexBuffer = yy_scan_string (String);
++    LexBuffer = DtParser_scan_string (String);
+     return (LexBuffer == NULL);
+ }
+ 
+diff --git a/source/compiler/prparser.l b/source/compiler/prparser.l
+index 10bd130..9cb3573 100644
+--- a/source/compiler/prparser.l
++++ b/source/compiler/prparser.l
+@@ -127,7 +127,7 @@ PrInitLexer (
+     char                    *String)
+ {
+ 
+-    LexBuffer = yy_scan_string (String);
++    LexBuffer = PrParser_scan_string (String);
+     return (LexBuffer == NULL);
+ }
+ 
+-- 
+2.11.0
+


### PR DESCRIPTION
This updates acpica, promotes the acpi tables to allarch and fixes 2 problems in the arduino.asli table:
- Linux 4.18 shows errors that 4.16 did not. These errors might be caused only when loading through configfs
- Recent patches to U-Boot allow us to test i2c-6, appears there is a mixup in the levels for mux and dir.

UPD: these patches make the timeouts on i2c-6 go away, but I haven't been able to connect a i2c device yet. If you can please connect one and test with `modprobe -i i2c-dev` followed by `i2cdetect -r -y 6`