### PR TITLE
Update acpica_20180810.bb

### DIFF
--- a/recipes-bsp/acpica/acpica_20180810.bb
+++ b/recipes-bsp/acpica/acpica_20180810.bb
@@ -16,7 +16,7 @@ COMPATIBLE_HOST = "(i.86|x86_64|arm|aarch64).*-linux"
 
 DEPENDS = "bison flex"
 
-SRC_URI = "https://acpica.org/sites/acpica/files/acpica-unix2-${PV}.tar.gz \
+SRC_URI = "https://www.coreboot.org/releases/crossgcc-sources/acpica-unix2-${PV}.tar.gz \
            file://rename-yy_scan_string-manually.patch \
            file://manipulate-fds-instead-of-FILE.patch \
            "


### PR DESCRIPTION
Replace Intel-owned URL for acpica package (now defunct since 2018 was a long time ago) with one from Coreboot.

Auto mirror-search wasn't finding anything & this was causing a build failure. 

This change will allow older versions of meta-intel-edison (Sumo32, with working MRAA(?)) to build again.